### PR TITLE
Bugfix/type nft mismatched types

### DIFF
--- a/cadence/contracts/Crediflow.cdc
+++ b/cadence/contracts/Crediflow.cdc
@@ -393,8 +393,8 @@ pub contract Crediflow {
 
             self.creatorNFTMap[recipentAddr] = NFTIdentifier(_id: id, _address: recipentAddr, _serial: serial)
             self.totalCreatorNFTSupply = self.totalCreatorNFTSupply + 1
-
-            recipient.deposit(token: <- token)
+            let forceToken <- token as! @NonFungibleToken.NFT
+            recipient.deposit(token: <- forceToken)
             return id
         }
 
@@ -414,8 +414,8 @@ pub contract Crediflow {
 
             self.admirerNFTMap[recipentAddr] = NFTIdentifier(_id: id, _address: recipentAddr, _serial: serial)
             self.totalAdmirerNFTSupply = self.totalAdmirerNFTSupply + 1
-
-            recipient.deposit(token: <- token)
+            let forceToken <- token as! @NonFungibleToken.NFT
+            recipient.deposit(token: <- forceToken)
             return id
         }
 


### PR DESCRIPTION
## summary

tx failure occurred in type casting when putting original nfts into the collection of ownerNfts.

## log

occur force cast bug?

```bash
ERR Project error [23:49:27]

❌ Error deploying your project. Runtime error encountered which means your code is incorrect, check details bellow.

Crediflow Errors:
mismatched types
   --> 192440c99cb17282.Crediflow:391:37
    |
391 |             recipient.deposit(token: <- token)
    |                                      ^^^^^^^^ expected `NonFungibleToken.NFT`, got `Crediflow.CreatorNFT`

error: mismatched types
   --> 192440c99cb17282.Crediflow:411:37
    |
411 |             recipient.deposit(token: <- token)
    |                                      ^^^^^^^^ expected `NonFungibleToken.NFT`, got `Crediflow.AdmirerNFT`
```

and Tx Error

```bash
❌ Transaction Error
execution error code 1101: [Error Code: 1101] error caused by: 1 error occurred:
	* transaction execute failed: [Error Code: 1101] cadence runtime error: Execution failed:
  --> 2d6e184858dc3b09fe4ec2be8d6548109c9ef7f163ffbbdf3abad446442f0da8:37:8
   |
37 |         self.Content.mintCreator(recipient: self.CreatorCollection)
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

error: failed to force-cast value: expected type `NonFungibleToken.NFT`, got `Crediflow.CreatorNFT`
   --> 192440c99cb17282.Crediflow:396:30
    |
396 |             let forceToken <- token as! @NonFungibleToken.NFT
    | 
```
