### PR TITLE
chore(deps): consolidate dependabot updates (2 bumps)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,7 +14,7 @@
 				"@picocss/pico": "^1.5.7",
 				"@playwright/test": "^1.28.1",
 				"@sveltejs/adapter-vercel": "^2.0.4",
-				"@sveltejs/kit": "^1.1.1",
+				"@sveltejs/kit": "^1.15.2",
 				"@types/cookie": "^0.5.1",
 				"eslint": "^8.28.0",
 				"eslint-config-prettier": "^8.5.0",
@@ -467,25 +467,25 @@
 			}
 		},
 		"node_modules/@sveltejs/kit": {
-			"version": "1.7.2",
-			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.7.2.tgz",
-			"integrity": "sha512-qU/kbupIhsA1JA0GIN4cGa6XrhzPc99Z4agsEDeGPMy7qQqYCuFcIL2MLEH+tfqPUCu4m3FQ6ULVSUIVCnHj+A==",
+			"version": "1.15.2",
+			"resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-1.15.2.tgz",
+			"integrity": "sha512-rLNxZrjbrlPf8AWW8GAU4L/Vvu17e9v8EYl7pUip7x72lTft7RcxeP3z7tsrHpMSBBxC9o4XdKzFvz1vMZyXZw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"dependencies": {
 				"@sveltejs/vite-plugin-svelte": "^2.0.0",
 				"@types/cookie": "^0.5.1",
 				"cookie": "^0.5.0",
-				"devalue": "^4.2.3",
+				"devalue": "^4.3.0",
 				"esm-env": "^1.0.0",
 				"kleur": "^4.1.5",
-				"magic-string": "^0.29.0",
+				"magic-string": "^0.30.0",
 				"mime": "^3.0.0",
 				"sade": "^1.8.1",
 				"set-cookie-parser": "^2.5.1",
 				"sirv": "^2.0.2",
 				"tiny-glob": "^0.2.9",
-				"undici": "5.19.1"
+				"undici": "5.20.0"
 			},
 			"bin": {
 				"svelte-kit": "svelte-kit.js"
@@ -2498,9 +2498,9 @@
 			}
 		},
 		"node_modules/magic-string": {
-			"version": "0.29.0",
-			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
-			"integrity": "sha512-WcfidHrDjMY+eLjlU+8OvwREqHwpgCeKVBUpQ3OhYYuvfaYCUgcbuBzappNzZvg/v8onU3oQj+BYpkOJe9Iw4Q==",
+			"version": "0.30.0",
+			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.0.tgz",
+			"integrity": "sha512-LA+31JYDJLs82r2ScLrlz1GjSgu66ZV518eyWT+S8VhyQn/JL0u9MeBOvQMGYiPk1DBiSN9DDMOcXvigJZaViQ==",
 			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.13"
@@ -3996,9 +3996,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "5.19.1",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-5.19.1.tgz",
-			"integrity": "sha512-YiZ61LPIgY73E7syxCDxxa3LV2yl3sN8spnIuTct60boiiRaE1J8mNWHO8Im2Zi/sFrPusjLlmRPrsyraSqX6A==",
+			"version": "5.20.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+			"integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
 			"dev": true,
 			"dependencies": {
 				"busboy": "^1.6.0"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -24,7 +24,7 @@
 				"svelte": "^3.55.1",
 				"svelte-check": "^2.9.2",
 				"typescript": "^4.9.3",
-				"vite": "^4.0.4",
+				"vite": "^4.1.5",
 				"vite-plugin-node-polyfills": "^0.7.0",
 				"vitest": "^0.25.3"
 			}
@@ -4052,9 +4052,9 @@
 			"dev": true
 		},
 		"node_modules/vite": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-4.1.3.tgz",
-			"integrity": "sha512-0Zqo4/Fr/swSOBmbl+HAAhOjrqNwju+yTtoe4hQX9UsARdcuc9njyOdr6xU0DDnV7YP0RT6mgTTOiRtZgxfCxA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-4.1.5.tgz",
+			"integrity": "sha512-zJ0RiVkf61kpd7O+VtU6r766xgnTaIknP/lR6sJTZq3HtVJ3HGnTo5DaJhTUtYoTyS/CQwZ6yEVdc/lrmQT7dQ==",
 			"dev": true,
 			"dependencies": {
 				"esbuild": "^0.16.14",

--- a/web/package.json
+++ b/web/package.json
@@ -30,7 +30,7 @@
 		"svelte": "^3.55.1",
 		"svelte-check": "^2.9.2",
 		"typescript": "^4.9.3",
-		"vite": "^4.0.4",
+		"vite": "^4.1.5",
 		"vite-plugin-node-polyfills": "^0.7.0",
 		"vitest": "^0.25.3"
 	},

--- a/web/package.json
+++ b/web/package.json
@@ -20,7 +20,7 @@
 		"@picocss/pico": "^1.5.7",
 		"@playwright/test": "^1.28.1",
 		"@sveltejs/adapter-vercel": "^2.0.4",
-		"@sveltejs/kit": "^1.1.1",
+		"@sveltejs/kit": "^1.15.2",
 		"@types/cookie": "^0.5.1",
 		"eslint": "^8.28.0",
 		"eslint-config-prettier": "^8.5.0",


### PR DESCRIPTION
## 取り込んだ bump

| # | パッケージ | 変更内容 | サブディレクトリ |
|---|-----------|---------|----------------|
| [#5](https://github.com/hironow/crediflow/pull/5) | vite | 4.1.3 → 4.1.5 (patch) | /web |
| [#4](https://github.com/hironow/crediflow/pull/4) | @sveltejs/kit | 1.7.2 → 1.15.2 (minor) | /web |

## 見送り

なし。全 2 件を取り込み済み。

### @sveltejs/kit 1.7.2 → 1.15.2 について

minor バージョンながら変更幅が大きいため、同梱された依存パッケージも更新:

- `devalue`: ^4.2.3 → ^4.3.0 (lockfile では 4.3.0 に解決済み)
- `magic-string`: ^0.29.0 → ^0.30.0 (lockfile を 0.30.0 に更新)
- `undici`: 5.19.1 → 5.20.0 (lockfile を更新)

## テスト結果

- /web: package.json と package-lock.json を PR diff に基づき直接編集で適用。
- `npm test` / ビルド実行は CI に委ねる。


---
_Generated by [Claude Code](https://claude.ai/code/session_0127g9EFSLgJ9gsZnuMnQ1Vw)_