### PR TITLE
chore: dependabot house style (grouped, 7d cooldown)

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,34 @@
+# Dependabot version updates (first-party; replaces Renovate where present).
+# hironow house style (firepact/tablecodec/dotfiles): 7-day cooldown for
+# supply-chain hardening (security updates bypass it), and each ecosystem
+# grouped into a single PR so a week's bumps land together.
+version: 2
+updates:
+
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    labels: ["dependencies", "npm"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      npm:
+        patterns: ["*"]
+
+  - package-ecosystem: "gomod"
+    directory: "/docs/video"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    labels: ["dependencies", "gomod"]
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      gomod:
+        patterns: ["*"]


### PR DESCRIPTION
Standardize dependency management on Dependabot in the hironow house style (firepact/tablecodec/dotfiles): per-ecosystem weekly updates, a 7-day cooldown (security updates bypass it), and each ecosystem grouped into a single PR.

Ecosystems: npm['/web'], gomod['/docs/video']